### PR TITLE
design: hexcode ColorExtension

### DIFF
--- a/app/Public Opinion for Stock/Public Opinion for Stock/Models/ColorExtension.swift
+++ b/app/Public Opinion for Stock/Public Opinion for Stock/Models/ColorExtension.swift
@@ -1,0 +1,32 @@
+//Hex code 쓰기
+// Color(hex: "#00000")
+
+import SwiftUI
+
+
+extension Color {
+    init(hex: String) {
+        let hex = hex.trimmingCharacters(in: CharacterSet.alphanumerics.inverted)
+        var int: UInt64 = 0
+        Scanner(string: hex).scanHexInt64(&int)
+        let a, r, g, b: UInt64
+        switch hex.count {
+        case 3: // RGB (12-bit)
+            (a, r, g, b) = (255, (int >> 8) * 17, (int >> 4 & 0xF) * 17, (int & 0xF) * 17)
+        case 6: // RGB (24-bit)
+            (a, r, g, b) = (255, int >> 16, int >> 8 & 0xFF, int & 0xFF)
+        case 8: // ARGB (32-bit)
+            (a, r, g, b) = (int >> 24, int >> 16 & 0xFF, int >> 8 & 0xFF, int & 0xFF)
+        default:
+            (a, r, g, b) = (1, 1, 1, 0)
+        }
+
+        self.init(
+            .sRGB,
+            red: Double(r) / 255,
+            green: Double(g) / 255,
+            blue:  Double(b) / 255,
+            opacity: Double(a) / 255
+        )
+    }
+}


### PR DESCRIPTION
hexcode 사용하기

- **주제:** "color에서 hexcode을 사용하기 위한 것."
- **관련 이슈:** #29 

## 변경 사항 설명
RGB 사용말고, 하단처럼 컬러코드 쓸 수 있습니당
text: Color(hex: "#FF0000")

## 구현 내용
- [ ] 구현(혹은 수정) 내용 1

## 스크린샷
<img width="430" alt="image" src="https://github.com/user-attachments/assets/f2df9f26-c2d2-4d97-aef7-114409414853" />


### ✅ 관련 기능 담당 팀원 확인
- [x] @bongjooncha
- [x] @Gimgang00
- [ ] @junhajk
- [x] @karynkim 
- [ ] @seungjaeyuu
- [ ]  @ChocopieA 
